### PR TITLE
Completing package requirement list for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Working with python, required is to have python installed and to use
 virtualenv. To do so, install them (for Fedora below)
 
 ```sh
-sudo dnf install -y python3 python3-devel python3-pip
+sudo dnf install -y python3 python3-devel python3-pip postgresql-devel rpm-build
 sudo pip install virtualenv
 ```
 


### PR DESCRIPTION
I ran into missing requirements during `pip install -r requirements.txt`. Missing packages were postgresql-devel and rpm-build for psycopg2 python requirement.
